### PR TITLE
Introduce install Makefile rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /build
 *.o
-dt_utils
+dt_util
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /build
+*.o
+dt_utils
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,22 @@
 SRC  := $(wildcard src/*.c)
 OBJS := $(SRC:%.c=%.o)
 
-all: dt_utils
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
 
-dt_utils: $(OBJS)
+all: dt_util
+
+dt_util: $(OBJS)
 	$(CC) $(LDFLAGS) $^ $(LOADLIBS) $(LDLIBS) -o $@
+
+.PHONY: install
+
+install: all
+	install -d $(DESTDIR)$(BINDIR)
+	install -m755 dt_util $(DESTDIR)$(BINDIR)
+	ln -s dt_util $(DESTDIR)$(BINDIR)/dt_utils
 
 .PHONY: clean
 
 clean:
-	rm -rf dt_utils $(OBJS)
+	rm -rf dt_util $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-SRC    := src/list.c src/dt.c src/main.c
-LDLIBS := 
+SRC  := $(wildcard src/*.c)
+OBJS := $(SRC:%.c=%.o)
 
 all: dt_utils
 
-dt_utils: $(SRC:%.c=%.o)
-	$(CC) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS) -o $@
+dt_utils: $(OBJS)
+	$(CC) $(LDFLAGS) $^ $(LOADLIBS) $(LDLIBS) -o $@
+
+.PHONY: clean
 
 clean:
-	$(RM) dt_utils $(SRC:%.c=%.o)
-
+	rm -rf dt_utils $(OBJS)


### PR DESCRIPTION
This change introduces an install Makefile rule that facilitates installing the program on supported systems.

In addition, the Makefile now compiles the project by its designated name, with any concerns regarding backwards compatibility addressed by using a symlink.

In other words, `dt_utils` -> `dt_util`, but `dt_utils` still exists (as a symlink to `dt_util`). This should reflect what has been documented in the README.